### PR TITLE
fixed rotor rpm scale bug

### DIFF
--- a/Models/Interior/Panel/Instruments/rpm/rpm.xml
+++ b/Models/Interior/Panel/Instruments/rpm/rpm.xml
@@ -65,8 +65,8 @@
     <property>rotors/main/rpm</property>
     <interpolation>
       <entry><ind>   0 </ind><dep>  0 </dep></entry>
-      <entry><ind> 265 </ind><dep> 11 </dep></entry>
-      <entry><ind> 615 </ind><dep> 88 </dep></entry>
+      <entry><ind> 274 </ind><dep> 11 </dep></entry>
+      <entry><ind> 530 </ind><dep> 88 </dep></entry>
     </interpolation>
     <center>
       <x-m> 0.000 </x-m>


### PR DESCRIPTION
The rotor rpm gauge scale was wrong, it should be on pair with the engine rpm. fixed now